### PR TITLE
feat(TravelDocument): dividing travel document into different types (ISSUE #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # equilibria-sharing_backend
 
-### UML:![](docs/equilibria-uml-18-01-2025.drawio.png)
+### UML:![](docs/equilibria-uml-27-01-2025.drawio.png)
 

--- a/docs/equilibria-uml-18-01-2025.drawio
+++ b/docs/equilibria-uml-18-01-2025.drawio
@@ -204,7 +204,7 @@
         <mxCell id="lRpwmT4PMg6yvVuO-Ubb-65" value="- id : Long (Auto-Generated)" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" vertex="1" parent="lRpwmT4PMg6yvVuO-Ubb-64">
           <mxGeometry y="26" width="360" height="26" as="geometry" />
         </mxCell>
-        <mxCell id="lRpwmT4PMg6yvVuO-Ubb-66" value="- passportNr : String" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rounded=0;shadow=0;html=0;" vertex="1" parent="lRpwmT4PMg6yvVuO-Ubb-64">
+        <mxCell id="lRpwmT4PMg6yvVuO-Ubb-66" value="- documentNr : String" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rounded=0;shadow=0;html=0;" vertex="1" parent="lRpwmT4PMg6yvVuO-Ubb-64">
           <mxGeometry y="52" width="360" height="26" as="geometry" />
         </mxCell>
         <mxCell id="lRpwmT4PMg6yvVuO-Ubb-67" value="- country : String" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rounded=0;shadow=0;html=0;" vertex="1" parent="lRpwmT4PMg6yvVuO-Ubb-64">

--- a/src/main/java/api/equilibria_sharing/controller/BookingController.java
+++ b/src/main/java/api/equilibria_sharing/controller/BookingController.java
@@ -72,9 +72,11 @@ public class BookingController {
         log.info("Main traveler after setting address: {}", mainTraveler);
 
         TravelDocument travelDocument = new TravelDocument();
-        travelDocument.setPassportNr(bookingRequest.getMainTraveler().getPassportNr());
+        travelDocument.setType(bookingRequest.getMainTraveler().getTravelDocumentType());
+        travelDocument.setDocumentNr(bookingRequest.getMainTraveler().getDocumentNr());
         travelDocument.setCountry(bookingRequest.getMainTraveler().getCountry());
         travelDocument.setIssueDate(bookingRequest.getMainTraveler().getIssueDate());
+        travelDocument.setExpiryDate(bookingRequest.getMainTraveler().getExpiryDate());
         travelDocument.setIssuingAuthority(bookingRequest.getMainTraveler().getIssuingAuthority());
 
         mainTraveler.setTravelDocument(travelDocument);
@@ -202,9 +204,11 @@ public class BookingController {
 
         // update the travel document of main traveler
         TravelDocument travelDocument = new TravelDocument();
-        travelDocument.setPassportNr(bookingRequest.getMainTraveler().getPassportNr());
+        travelDocument.setType(bookingRequest.getMainTraveler().getTravelDocumentType());
+        travelDocument.setDocumentNr(bookingRequest.getMainTraveler().getDocumentNr());
         travelDocument.setCountry(bookingRequest.getMainTraveler().getCountry());
         travelDocument.setIssueDate(bookingRequest.getMainTraveler().getIssueDate());
+        travelDocument.setExpiryDate(bookingRequest.getMainTraveler().getExpiryDate());
         travelDocument.setIssuingAuthority(bookingRequest.getMainTraveler().getIssuingAuthority());
         mainTraveler.setTravelDocument(travelDocument);
         personRepository.save(mainTraveler);

--- a/src/main/java/api/equilibria_sharing/controller/example_post_from_frontend.json
+++ b/src/main/java/api/equilibria_sharing/controller/example_post_from_frontend.json
@@ -1,63 +1,34 @@
 {
-  "accommodation": {
-    "name": "Villa Seaside",
-    "type": "APARTMENT",
-    "description": "whatever",
-    "maxGuests": 12,
-    "pricePerNight": 47.31
-  },
-  "apartmentCountry": "ITALY",
-  "mainPerson": {
-    "mainTraveler": true,
-    "firstName": "Mario",
-    "lastName": "Rossi",
+  "accommodationId": 1,
+  "mainTraveler": {
+    "firstName": "John",
+    "lastName": "Doe",
     "gender": "MALE",
-    "birthDate": "1985-04-12",
-    "travelDocument": {
-      "passportNr": "X12345678",
-      "country": "ITALY",
-      "issueDate": "2010-05-01",
-      "issuing_authority": "Ministero dell'Interno"
-    },
-    "address": {
-      "street": "Via Roma",
-      "city": "Napoli",
-      "zipCode": "80100",
-      "country": "ITALY"
-    },
-    "mainTravelerRef": ""
+    "birthDate": "1985-05-15",
+    "travelDocumentType": "PASSPORT",
+    "documentNr": "A1234567",
+    "country": "USA",
+    "issueDate": "2020-01-01",
+    "expiryDate": "2030-01-01",
+    "issuingAuthority": "US Department of State",
+    "city": "Braunau",
+    "postalCode": 4950,
+    "street": "Am Anger",
+    "houseNumber": 13,
+    "addressAdditional": ""
   },
-  "persons": [
+  "additionalGuests": [
     {
-      "mainTraveler": false,
-      "firstName": "Luigi",
-      "lastName": "Rossi",
-      "gender": "MALE",
-      "birthDate": "1990-07-25",
-      "address": {
-        "street": "Via Milano",
-        "city": "Roma",
-        "zipCode": "00100",
-        "country": "ITALY"
-      },
-      "mainTravelerRef": "Mario-Rossi-1985"
+      "firstName": "Jane",
+      "lastName": "Doe",
+      "birthDate": "1988-07-20"
     },
     {
-      "mainTraveler": false,
-      "firstName": "Anna",
-      "lastName": "Verdi",
-      "gender": "FEMALE",
-      "birthDate": "2005-11-03",
-      "address": {
-        "street": "Via Firenze",
-        "city": "Firenze",
-        "zipCode": "50100",
-        "country": "ITALY"
-      },
-      "mainTravelerRef": "Mario-Rossi-1985"
+      "firstName": "Mike",
+      "lastName": "Smith",
+      "birthDate": "1990-10-30"
     }
   ],
-  "checkIn": "2025-07-15T14:00:00",
-  "expectedCheckOut": "2025-07-20T10:00:00",
-  "actualCheckOut": "2025-07-19T09:30:00"
+  "checkIn": "2025-02-01T14:00:00",
+  "expectedCheckOut": "2025-02-10T10:00:00"
 }

--- a/src/main/java/api/equilibria_sharing/model/TravelDocument.java
+++ b/src/main/java/api/equilibria_sharing/model/TravelDocument.java
@@ -11,20 +11,33 @@ public class TravelDocument {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String passportNr;
+    @Enumerated(EnumType.STRING)
+    private TravelDocumentType type;
+
+    private String documentNr;
 
     private String country;
 
     private LocalDate issueDate;
 
+    private LocalDate expiryDate;
+
     private String issuingAuthority;
 
-    public String getPassportNr() {
-        return passportNr;
+    public TravelDocumentType getType() {
+        return type;
     }
 
-    public void setPassportNr(String passportNr) {
-        this.passportNr = passportNr;
+    public void setType(TravelDocumentType type) {
+        this.type = type;
+    }
+
+    public String getDocumentNr() {
+        return documentNr;
+    }
+
+    public void setDocumentNr(String documentNr) {
+        this.documentNr = documentNr;
     }
 
     public String getCountry() {
@@ -51,13 +64,31 @@ public class TravelDocument {
         this.issuingAuthority = issuing_authority;
     }
 
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public LocalDate getExpiryDate() {
+        return expiryDate;
+    }
+
+    public void setExpiryDate(LocalDate expiryDate) {
+        this.expiryDate = expiryDate;
+    }
+
     @Override
     public String toString() {
         return "TravelDocument{" +
                 "id=" + id +
-                ", passportNr='" + passportNr + '\'' +
+                ", type=" + type +
+                ", documentNr='" + documentNr + '\'' +
                 ", country='" + country + '\'' +
                 ", issueDate=" + issueDate +
+                ", expiryDate=" + expiryDate +
                 ", issuingAuthority='" + issuingAuthority + '\'' +
                 '}';
     }

--- a/src/main/java/api/equilibria_sharing/model/TravelDocumentType.java
+++ b/src/main/java/api/equilibria_sharing/model/TravelDocumentType.java
@@ -1,0 +1,5 @@
+package api.equilibria_sharing.model;
+
+public enum TravelDocumentType {
+    PASSPORT, IDENTITY_CARD, DRIVER_LICENSE, OTHER
+}

--- a/src/main/java/api/equilibria_sharing/model/requests/MainTravelerRequest.java
+++ b/src/main/java/api/equilibria_sharing/model/requests/MainTravelerRequest.java
@@ -1,7 +1,7 @@
 package api.equilibria_sharing.model.requests;
 
-import api.equilibria_sharing.model.Address;
 import api.equilibria_sharing.model.Gender;
+import api.equilibria_sharing.model.TravelDocumentType;
 
 import java.time.LocalDate;
 
@@ -10,9 +10,11 @@ public class MainTravelerRequest {
     private String lastName;
     private Gender gender;
     private LocalDate birthDate;
-    private String passportNr;
+    private TravelDocumentType travelDocumentType;
+    private String documentNr;
     private String country;
     private LocalDate issueDate;
+    private LocalDate expiryDate;
     private String issuingAuthority;
     private String city;
     private int postalCode;
@@ -53,12 +55,12 @@ public class MainTravelerRequest {
         this.birthDate = birthDate;
     }
 
-    public String getPassportNr() {
-        return passportNr;
+    public String getDocumentNr() {
+        return documentNr;
     }
 
-    public void setPassportNr(String passportNr) {
-        this.passportNr = passportNr;
+    public void setDocumentNr(String documentNr) {
+        this.documentNr = documentNr;
     }
 
     public String getCountry() {
@@ -123,5 +125,21 @@ public class MainTravelerRequest {
 
     public void setAddressAdditional(String addressAdditional) {
         this.addressAdditional = addressAdditional;
+    }
+
+    public LocalDate getExpiryDate() {
+        return expiryDate;
+    }
+
+    public void setExpiryDate(LocalDate expiryDate) {
+        this.expiryDate = expiryDate;
+    }
+
+    public TravelDocumentType getTravelDocumentType() {
+        return travelDocumentType;
+    }
+
+    public void setTravelDocumentType(TravelDocumentType travelDocumentType) {
+        this.travelDocumentType = travelDocumentType;
     }
 }


### PR DESCRIPTION
Fixing ISSUE #1:
- Now the `TravelDocument` Model is divided into different types (via `TravelDocumentType`)
- The following `TravelDocumentType`s are possible:
  -` PASSPORT`
  - `DIVER_LICENSE`
  - `IDENTITY_CARD`
  - `OTHER`

- Plus the TravelDocument class now has the attribute `expiryDate` (for obvious reasons)


New UML:
![equilibria-uml-27-01-2025 drawio](https://github.com/user-attachments/assets/9ebef6cc-84e2-4703-9c30-57cce660c032)